### PR TITLE
Removed makeStyle from FullWidthTabs

### DIFF
--- a/src/components/Jobs/ViewJobs/FullWidthTabs.js
+++ b/src/components/Jobs/ViewJobs/FullWidthTabs.js
@@ -1,7 +1,6 @@
 import React, {  useEffect,useState } from 'react'; 
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
-import { makeStyles } from '@mui/styles'; // @mui/styles | @material-ui/core/styles
 import { useTheme } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Tabs from '@mui/material/Tabs';
@@ -10,31 +9,13 @@ import { TabPanel, a11yProps } from '../../../common/TabMenu/TabStyles';
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useDispatch,useSelector } from 'react-redux';  
 import { getAllJobs } from '../../../actions/action';
-
 import DataTable from './DataTable';
 import ControlledAccordions from './ControlledAccordions';
 import SearchBar from '../../../common/SearchBar';
 import SimpleBackdrop from '../../Loading/SimpleBackdrop';
 
 
-const useStyles = makeStyles(() => ({
-  root: {
-    width: '60vw',
-  },
-  title: {
-    color: "#1a1a1a",
-    fontFamily: "Comfortaa",
-    textAlign: 'center',
-    marginTop: '1rem',
-    marginBottom: '1rem',
-    fontSize: '32px !important',
-    fontWeight: '700'
-  }
-}));
-
-
 export const FullWidthTabs = ({ history, callback }) => {
-  const classes = useStyles();
   const theme = useTheme();
   const [value, setValue] = useState(0);
   const [searchInitiated, setSearchInitiated] = useState(false);
@@ -60,9 +41,9 @@ export const FullWidthTabs = ({ history, callback }) => {
 
 
   return (
-    <Container maxWidth="lg" className={classes.root}>
+    <Container maxWidth="lg" >
       <header>
-        <p className={`${classes.title}`}>Jobs</p>
+        <p className='title'>Jobs</p>
         <SearchBar setSearchInitiated={setSearchInitiated} />
         <Button
           type='submit'
@@ -95,7 +76,6 @@ export const FullWidthTabs = ({ history, callback }) => {
           <Tab label="Active" {...a11yProps(2)} />
         </Tabs>
       </AppBar>
-
 
       <TabPanel value={value} index={0} dir={theme.direction} >
         {
@@ -138,11 +118,9 @@ export const FullWidthTabs = ({ history, callback }) => {
             : <ControlledAccordions
               jobs={activeJobs}
               parentCallback={callback}
-
             />
         }
       </TabPanel>
-
       <SimpleBackdrop loading={jobs?.loading} />
     </Container>
   );

--- a/src/components/Jobs/ViewJobs/viewjobs.css
+++ b/src/components/Jobs/ViewJobs/viewjobs.css
@@ -26,6 +26,23 @@ tr.MuiTableRow-root.MuiTableRow-hover {
     font-weight: 700;
 }
 
+/****** title font /******/
+.title {
+    color: #1a1a1a;
+    font-family: Comfortaa;
+    text-align: center;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    font-size: 32px !important;
+    font-weight: 700;
+  }
+
+/****** Desktop Viewport ******/
+@media screen and (min-width: 877px) {
+
+}
+
+/****** Mobile Viewport ******/
 @media screen and (max-width: 600px) {
     .makeStyles-root-4 { width: 100% !important; }
     .MuiContainer-root { width: 100% !important; }

--- a/src/pages/login/login.css
+++ b/src/pages/login/login.css
@@ -11,7 +11,7 @@
 /******  submit mui theme ******/
 
 
-/* Desktop Viewport */
+/****** Desktop Viewport ******/
 @media screen and (min-width: 877px) {
     /****** mui theme ******/
     .wave {


### PR DESCRIPTION
## Rationale
Removed the makeStyles from the FullWidthTabs because it is now a legacy styling solution to be fully deprecated once the next version gets released.

## Advice for Reviewers & Testing Notes

npm install 
- Explain how your change should be reviewed, and where reviewers should direct their attention.
- Explain (where relevant) how your change can be tested.

## Screenshots:
n/a

- Add a screenshot or two of your changes, where applicable.

## Task Name
Refactor: Migrate Component Styles To Plain CSS #152

- Issue Title


## Linting Checklist
- [ ] No commented code
- [ ] Code Formatted nicely (Prettier)
- [ ] PR your own code before you assign reviewers