### PR TITLE
Migrated component to use CSS.

### DIFF
--- a/src/components/Jobs/JobDiary/JobDiaryAccordions.js
+++ b/src/components/Jobs/JobDiary/JobDiaryAccordions.js
@@ -11,42 +11,12 @@ import CameraAltIcon from '@mui/icons-material/CameraAlt';
 import EditIcon from '@mui/icons-material/Edit';
 import Button from '@mui/material/Button';
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { makeStyles } from '@mui/styles';
 import { useDispatch, useSelector } from 'react-redux';
 import PhotoViewerDialog from '../../../common/PhotoViewerDialog';
 import { getActivities } from '../../../actions/activityAction';
-
-
-const useStyles = makeStyles(() => ({
-  root: { width: '60vw' },
-  iconColor: { color: 'black' },
-  accordion: { marginBottom: '30%' },
-  content: {
-    marginBottom: '10%',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    marginTop: '-10px'
-  },
-  activityButtonMobile: {
-    position: 'relative',
-    top: '2rem',
-    left: '1rem ',
-    height: '35% !important',
-    width: '35% !important',
-    padding: '5px 15px',
-    minWidth: '10px',
-    backgroundColor: '#ffffff !important',
-    border: '1px solid rgb(105,105,105) !important',
-    borderRadius: '50px !important',
-    "border-style": 'solid !important',
-    "border-color": 'black !important',
-    boxShadow: '0 6px 5px #999 !important',
-  },
-}));
-
+import "./jobdiary.css";
 
 export default function JobDiaryAccordions(props) {
-  const classes = useStyles();
   const [expanded, setExpanded] = React.useState('panel1');
   const dispatch = useDispatch();
   const { activity } = useSelector(state => state);
@@ -96,11 +66,13 @@ export default function JobDiaryAccordions(props) {
         key={act.id}
         expanded={expanded === 'panel1'}
         onChange={handleChange('panel1')}
+        className="accordionMobile"
       >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           aria-controls="panel1bh-content"
           id="panel1bh-header"
+          sx={{ width: '90%' }}
         >
           <Container>
             <Typography sx={{ width: '44%', flexShrink: 0, marginLeft: '-1.4rem' }}>
@@ -116,7 +88,7 @@ export default function JobDiaryAccordions(props) {
           </Container>
         </AccordionSummary>
         <AccordionDetails >
-          <Container className={classes.content}>
+          <Container className="content">
             <Typography sx={{ width: '31%', flexShrink: 0, marginLeft: '-0.7rem' }}>
               Created on
             </Typography>
@@ -175,8 +147,8 @@ export default function JobDiaryAccordions(props) {
   });
 
   return (
-    <Container maxWidth="lg" className={classes.root}>
-      <Grid container spacing={0} className={classes.accordion}>
+    <Container maxWidth="lg" className='root'>
+      <Grid container spacing={0} className='accordion'>
         <Grid item xs={8}>
           <p
             className='title'
@@ -194,12 +166,12 @@ export default function JobDiaryAccordions(props) {
         <Grid item xs={4}>
           <Button
             variant="outlined"
-            className={classes.activityButtonMobile}
+            className='activityButtonMobile'
             onMouseUp={handleClickOpenCreateForm}
             
           >
             <NoteAddIcon
-              className={classes.iconColor} />
+              className='iconColor' />
           </Button>
         </Grid>
         <Grid item xs={12}>

--- a/src/components/Jobs/JobDiary/jobdiary.css
+++ b/src/components/Jobs/JobDiary/jobdiary.css
@@ -1,52 +1,36 @@
-/*
-div#add-section {
-    margin-bottom: 2%;
+/****** Desktop Viewport ******/
+@media screen and (min-width: 877px) {
+    .root { width: 60vw; };
+    .iconColor { color: black; };
+    .accordion { margin-bottom: 30%; };
+    .content {
+      margin-bottom: 10%;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: -10px;
+    }
 }
 
-button.MuiButtonBase-root.MuiButton-root.MuiButton-outlined {
-    border: 1px solid rgba(0, 0, 0, 0.23);
-    padding: 5px 15px;
-    min-width: 10px;
-    height: 30px;
-    background-color: #ffffff;
-    border: none;
-    box-shadow: 0 4px 8px 0 rgb(0 0 0 / 20%), 0 6px 20px 0 rgb(0 0 0 / 19%);
-    left: 2rem;
-}
-
-svg#icon {
-    font-size: 400px;
-    padding: 0 5%;
-    margin: 0 5%;
-}
-
-button.MuiButtonBase-root.MuiButton-root.MuiButton-outlined:hover {
-    background-color: rgb(117, 117, 115);
-}
-
+/****** Mobile Viewport ******/
 @media screen and (max-width: 600px) {
-    svg#icon {
-        font-size: 250px;
-        padding: 0;
-        margin: 0;
+    /* Adds a margin at the last accordion*/
+    .accordionMobile:last-of-type { 
+        margin-bottom: 30% !important;  
     }
 
-    button.MuiButtonBase-root.MuiButton-root.MuiButton-outlined {
-        border: 1px solid rgba(0, 0, 0, 0.23);
-        padding: 5px 15px;
-        min-width: 10px;
-        height: 80%;
-        background-color: #ffffff;
-        border: none;
-        box-shadow: 0 4px 8px 0 rgb(0 0 0 / 20%), 0 6px 20px 0 rgb(0 0 0 / 19%);
+    .activityButtonMobile {
+        position: relative !important;
+        top: 1rem;
         left: 1rem;
-    }
-
-    button:active {
-        background-color: rgb(207, 206, 206) !important;
-        box-shadow: 0 5px #666  !important;
-        transform: translateY(4px) !important;
+        height: 3.1rem !important;
+        width: 0% !important;
+        padding: 5px 15px !important;
+        min-width: 10px;
+        background-color: #ffffff !important;
+        border: 1px solid rgb(105,105,105) !important;
+        border-radius: 50px !important;
+        border-style: solid !important;
+        border-color: black !important;
+        box-shadow: 0 6px 5px #999 !important;
     }
 }
-
-*/


### PR DESCRIPTION
## Rationale
Migrated the JobDiaryAccordions component to use plain css and sx prop of material ui because the styling engine that was used is deprecated.

## Advice for Reviewers & Testing Notes

npm install 
- Explain how your change should be reviewed, and where reviewers should direct their attention.
- Explain (where relevant) how your change can be tested.

## Screenshots:
nil

## Task Name
Refactor: Migrate Component Styles To Plain CSS](https://github.com/codesydney/taskstech/issues/152)

- Issue Title


## Linting Checklist
- [ ] No commented code
- [ ] Code Formatted nicely (Prettier)
- [ ] PR your own code before you assign reviewers